### PR TITLE
✨ Allow filtering of tags using regex on title

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ make package
 # Configuration
 
 The following example polls github every 4 hours, and filters
-tags for Golang and Kubernetes, but not for Prometheus.
+on tag names for Golang and Kubernetes, on title for AdoptOpenJDK,
+an no filter for Prometheus.
 New releases are notified in a Slack channel.
 
 ```
@@ -32,6 +33,8 @@ projects:
   - projectUrl: "https://github.com/kubernetes/kubernetes"
     tagFilter: "v\\d+(\\.\\d+){2}$"
   - projectUrl: "https://github.com/prometheus/prometheus"
+  - projectUrl: "https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries"
+    titleFilter: ".*GA Release.*"
 
 pollFrequency: 4h
 

--- a/model/github_project.go
+++ b/model/github_project.go
@@ -3,4 +3,5 @@ package model
 type GithubProject struct {
 	ProjectUrl string `yaml:"projectUrl"`
 	TagFilter  string `yaml:"tagFilter"`
+	TitleFilter  string `yaml:"titleFilter"`
 }

--- a/releases/releases_handler.go
+++ b/releases/releases_handler.go
@@ -38,6 +38,11 @@ func NewReleasesHandler(projects []model.GithubProject, pollFrequency time.Durat
 		if err != nil {
 			return nil, err
 		}
+
+		_, err = regexp.Compile(p.TitleFilter)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	h := &Handler{
@@ -119,14 +124,24 @@ func (h *Handler) RunSingle(project model.GithubProject, notify bool) error {
 		h.log.Debugf("Got a tag %s", tag)
 
 		// filter tag
-		matches, err := filterTag(tag, project.TagFilter)
+		tagMatches, err := filterTag(tag, project.TagFilter)
 		if err != nil {
 			return err
 		}
-		if !matches {
+		if !tagMatches {
 			continue
 		}
 		h.log.Debugf("Tag %s matches filter %s", tag, project.TagFilter)
+
+		// filter title
+		titleMatches, err := filterTag(item.Title, project.TitleFilter)
+		if err != nil {
+			return err
+		}
+		if !titleMatches {
+			continue
+		}
+		h.log.Debugf("Title %s matches filter %s", item.Title, project.TitleFilter)
 
 		// check if it exists
 		exists, err := h.storageHandler.TagExists(project.ProjectUrl, tag)

--- a/test-data/test-config.yml
+++ b/test-data/test-config.yml
@@ -2,7 +2,8 @@ projects:
   - projectUrl: "p1"
     tagFilter: "t1"
   - projectUrl: "p2"
-    tagFilter: "t2"
+    tagFilter: "tag2"
+    titleFilter: "title2"
   - projectUrl: "p3"
 
 pollFrequency: 30m


### PR DESCRIPTION
This PR adds regex filtering capability on the title, in addition to the tag.

The configuration would looks like the following real-life example `https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases`, where the tags of a release `jdk-11.0.10+9` is hard to distinguish from the tag of a RC `jdk-11.0.10+8`

```   
projects:
  - projectUrl: "https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries"
    titleFilter: ".*GA Release.*"
```

Filtering on tag AND title works, but both must match, i.e. matching on tag OR title is not possible in the current implementation